### PR TITLE
Export NativeModule

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -23,6 +23,7 @@
     });
     EventEmitter.call(process);
 
+    process.NativeModule = NativeModule;
     process.EventEmitter = EventEmitter; // process.EventEmitter is deprecated
 
     var isRenderer = process.argv[2] == '--type=renderer';


### PR DESCRIPTION
So that we can override its `::compile` method to make use of v8's compile cache in Atom, as we do for `Module::compile`.

/cc: @zcbenz 